### PR TITLE
Get post endpoint implemented for single articles

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,6 +70,23 @@ app.post("/login", function(req, res) {
     );
 });
 
+// Endpoint to return the data of a single post
+app.get("/post", function(req, res) {
+    pool.query(
+        'SELECT p.title, p.body AS post_body, u.username AS post_username, c.comment_id, c.body AS comment_body, cu.username AS comment_username FROM post p LEFT JOIN comment c ON p.post_id = c.post_id JOIN user u ON p.user_id = u.user_id JOIN user cu ON c.user_id = cu.user_id WHERE p.post_id = ?;',
+        [req.query.id], 
+        (error, results) => {
+            console.log(results);
+            if (error) {
+                res.status(500);
+            }
+            else {
+                res.status(200).json(results);
+            }
+        }
+    );
+});
+
 app.get("/posts", function(req, res) {
     pool.query(
         'SELECT username, post_id, title, body FROM post INNER JOIN user ON post.user_id=user.user_id WHERE post_id < ? LIMIT ?;',


### PR DESCRIPTION
/post Get endpoint created which returns the following data to be loaded onto the single article page:

- Post title
- Post body
- Post author
- Comment ID
- Comment body
- Comment author

Uses a query to search for the specific post, I figured that was best since it is a get request and those usually do not provide a payload