### PR TITLE
Browse page wont scroll fix

### DIFF
--- a/Public/Browse.html
+++ b/Public/Browse.html
@@ -167,7 +167,6 @@
     }
 
     const scrollEventListener = () => {
-        console.log(window.scrollY + window.innerHeight, document.documentElement.scrollHeight)
         if (window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) { 
             //the -1 is a stopgap fix for an issue where new posts would not load because the scrollY would technically be ".3333" too low.
 

--- a/Public/Browse.html
+++ b/Public/Browse.html
@@ -167,7 +167,10 @@
     }
 
     const scrollEventListener = () => {
-        if (window.scrollY + window.innerHeight >= document.documentElement.scrollHeight) {
+        console.log(window.scrollY + window.innerHeight, document.documentElement.scrollHeight)
+        if (window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) { 
+            //the -1 is a stopgap fix for an issue where new posts would not load because the scrollY would technically be ".3333" too low.
+
             populateBrowse();
         }
     };


### PR DESCRIPTION
Fixed an issue relating to (probably screen size) scrolling where the scroll event wouldnt be triggered because the value was .3 too low.