### PR TITLE
Fix HTML path references. Dotenv override setting.

### DIFF
--- a/Public/Login.html
+++ b/Public/Login.html
@@ -40,6 +40,7 @@
             body: JSON.stringify(json),
         })
         .then(response => {
+            console.log(response);
             if (response.status === 401) {
                 displayError("Invalid credentials.");
                 throw new Error("Invalid credentials");

--- a/Public/Login.html
+++ b/Public/Login.html
@@ -40,7 +40,7 @@
             body: JSON.stringify(json),
         })
         .then(response => {
-            console.log(response);
+            console.log(response.status);
             if (response.status === 401) {
                 displayError("Invalid credentials.");
                 throw new Error("Invalid credentials");

--- a/Routes/login.js
+++ b/Routes/login.js
@@ -14,6 +14,7 @@ router.post("/", function(req, res) {
             console.log(results);
             if (error) {
                 res.status(500);
+                console.log(error);
             }
             else if (!results.length) {
                 res.status(401).send("Invalid credentials");

--- a/server.js
+++ b/server.js
@@ -3,12 +3,12 @@ const express = require('express');
 const mysql = require('mysql2');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
-require('dotenv').config();
+require('dotenv').config({ override: true });
 
 // Set up express app
 const app = express();
 app.use(express.json());
-app.use(express.static(__dirname + "/public"));
+app.use(express.static(__dirname + "/Public"));
 app.use(cors());
 app.use(cookieParser());
 
@@ -70,7 +70,7 @@ app.use('/profile', profileRoutes);
 
 // Server routes
 app.get("/", function (req, res) {
-    res.sendFile(__dirname + "/public/Login.html");
+    res.sendFile(__dirname + "/Public/Login.html");
 });
 
 //wtf is this even used for
@@ -91,12 +91,12 @@ app.get("/username", function(req, res) {
 
 
 app.get('/article', function (req, res) {
-    res.sendFile(__dirname + "/public/Article.html");
+    res.sendFile(__dirname + "/Public/Article.html");
 })
 
 
 app.get('/browse', function(req, res) {
-    res.sendFile(__dirname + "/public/Browse.html");
+    res.sendFile(__dirname + "/Public/Browse.html");
 });
 
 


### PR DESCRIPTION
# Changes made

This branch was initially made to fix the references to /Public. While I was fixing that I discovered an issue with how we load the dotenv file.

## 🌐 Public/Login.html
- Add logging for the client side /login response status.

## 📜 Routes/login.js
- Add logging for server side /login errors. 

## 📜 server.js
- Add override option to dotenv. This will override any process.env variables that overlap with our dotenv file.
- Change references to /public to /Public. 